### PR TITLE
Corrected a problem related to the target destination of a package.

### DIFF
--- a/src/son/package/package.py
+++ b/src/son/package/package.py
@@ -64,6 +64,7 @@ class Packager(object):
 
                 if len(os.listdir(dst_path)) > 0: # dir not empty?
                     log.error("Destination directory '{}' is not empty".format(os.path.abspath(dst_path)))
+                    sys.stderr.write("ERROR:Destination directory '{}' is not empty\n".format(os.path.abspath(dst_path)))
                     exit(1)
 
                 self._dst_path = os.path.abspath(dst_path)


### PR DESCRIPTION
Issue #31 is corrected. 
- If the DIR passed in the argument -d is not empty it does not allow to create a package.
- If DIR does not exist, it will create it.
