### PR TITLE
Corrected bug in packaging duplicate VNF entries

### DIFF
--- a/src/son/package/package.py
+++ b/src/son/package/package.py
@@ -144,10 +144,12 @@ class Packager(object):
         except ValidationError as e:
             log.error("Failed to validate Package Descriptor. Aborting package creation.")
             log.debug(e)
+            self._package_descriptor = None
             return
         except SchemaError as e:
             log.error("Invalid Package Descriptor Schema.")
             log.debug(e)
+            self._package_descriptor = None
             return
 
     @performance


### PR DESCRIPTION
A package was being generated, despite of triggering a validation error, with VNFs with the same ID in the project source folder. Now, upon validation error, the packaging process is interrupted.
