### PR TITLE
son-package exit code

### DIFF
--- a/src/son/package/package.py
+++ b/src/son/package/package.py
@@ -461,7 +461,7 @@ class Packager(object):
 
         # Validate all needed information
         if not self._package_descriptor:
-            log.error("Missing package descriptor. Failed to generate package.")
+            log.critical("Missing package descriptor. Failed to generate package.")
             exit(1)
 
         # Generate package file


### PR DESCRIPTION
The son-package should exit with an error code when it fails to package the project. This is very important, particularly in the CI environment to be able to abort and detect errors.
