### PR TITLE
Enforce the use of library validators to be version 0.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         package_data= {
             'son': ['package/templates/*', 'workspace/samples/*']
         },
-        install_requires=['setuptools', 'pyaml', 'jsonschema', 'validators', 'requests', 'coloredlogs'],
+        install_requires=['setuptools', 'pyaml', 'jsonschema', 'validators==0.10', 'requests', 'coloredlogs'],
         zip_safe=False,
         entry_points={
             'console_scripts': [


### PR DESCRIPTION
Newer versions of this library consider localhost IP (127.0.0.1) to be invalid.
