### PR TITLE
Revert "*Enforce the use of library validators to be version 0.10"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         package_data= {
             'son': ['package/templates/*', 'workspace/samples/*']
         },
-        install_requires=['setuptools', 'pyaml', 'jsonschema', 'validators==0.10', 'requests', 'coloredlogs'],
+        install_requires=['setuptools', 'pyaml', 'jsonschema', 'validators', 'requests', 'coloredlogs'],
         zip_safe=False,
         entry_points={
             'console_scripts': [


### PR DESCRIPTION
This reverts commit a3a5eb6438fc029072c4a4fdecafcd3386341b50.

The problem mentioned in issue #93 is now solved. Validators library was updated to support the correct validation of private/local IP addresses.
