### PR TITLE
Correct installation of setuptools >34.0.0

### DIFF
--- a/tools/distribute/ubuntu14.04.build-deb.Dockerfile
+++ b/tools/distribute/ubuntu14.04.build-deb.Dockerfile
@@ -5,6 +5,9 @@ RUN     apt-get update \
         && apt-get install -y python3-pip dpkg-dev fakeroot \
         && apt-get install -y python3-dev python3-pycparser \
         && apt-get install -y build-essential libssl-dev libffi-dev \
+        # Installing setuptools (now in >v34.0.0 dependencies must be installed in advance)
+        && pip3 install wincertstore==0.2 certifi==2016.9.26 six>=1.10.0 packaging>=16.8 appdirs>=1.4.0 \
+        && pip3 install setuptools==34.0.2 \
         ## install py2deb package converter
         && pip3 install py2deb \
         ## generate utf8 locale, otherwise py2deb will result in error!

--- a/tools/distribute/ubuntu14.04.build-deb.Dockerfile
+++ b/tools/distribute/ubuntu14.04.build-deb.Dockerfile
@@ -5,7 +5,7 @@ RUN     apt-get update \
         && apt-get install -y python3-pip dpkg-dev fakeroot \
         && apt-get install -y python3-dev python3-pycparser \
         && apt-get install -y build-essential libssl-dev libffi-dev \
-        # Installing setuptools (now in >v34.0.0 dependencies must be installed in advance)
+        ## Installing setuptools (now in >v34.0.0 dependencies must be installed in advance)
         && pip3 install wincertstore==0.2 certifi==2016.9.26 six>=1.10.0 packaging>=16.8 appdirs>=1.4.0 \
         && pip3 install setuptools==34.0.2 \
         ## install py2deb package converter

--- a/tools/distribute/ubuntu16.04.build-deb.Dockerfile
+++ b/tools/distribute/ubuntu16.04.build-deb.Dockerfile
@@ -5,11 +5,11 @@ RUN     apt-get update \
         && apt-get install -y python3-pip dpkg-dev fakeroot \
         && apt-get install -y python3-dev python3-pycparser \
         && apt-get install -y build-essential libssl-dev libffi-dev \
-        ## install py2deb package converter
-        && pip3 install --upgrade pip \
-        # Installing setuptools (now in >v34.0.0 dependencies must be installed in advance)
+        ## && pip3 install --upgrade pip \
+        ## Installing setuptools (now in >v34.0.0 dependencies must be installed in advance)
         && pip3 install wincertstore==0.2 certifi==2016.9.26 six>=1.10.0 packaging>=16.8 appdirs>=1.4.0 \
         && pip3 install setuptools==34.0.2 \
+        ## install py2deb package converter
         && pip3 install py2deb \
         ## generate utf8 locale, otherwise py2deb will result in error!
         && locale-gen en_US.UTF-8 \

--- a/tools/distribute/ubuntu16.04.build-deb.Dockerfile
+++ b/tools/distribute/ubuntu16.04.build-deb.Dockerfile
@@ -5,12 +5,14 @@ RUN     apt-get update \
         && apt-get install -y python3-pip dpkg-dev fakeroot \
         && apt-get install -y python3-dev python3-pycparser \
         && apt-get install -y build-essential libssl-dev libffi-dev \
-        ## && pip3 install --upgrade pip \
+        && pip3 install --upgrade pip
+
         ## Installing setuptools (now in >v34.0.0 dependencies must be installed in advance)
-        && pip3 install wincertstore==0.2 certifi==2016.9.26 six>=1.10.0 packaging>=16.8 appdirs>=1.4.0 \
-        && pip3 install setuptools==34.0.2 \
+RUN     pip3 install wincertstore==0.2 certifi==2016.9.26 six>=1.10.0 packaging>=16.8 appdirs>=1.4.0 \
+        && pip3 install setuptools==34.0.2
+
         ## install py2deb package converter
-        && pip3 install py2deb \
+RUN     pip3 install py2deb \
         ## generate utf8 locale, otherwise py2deb will result in error!
         && locale-gen en_US.UTF-8 \
         && mkdir -p /son-cli/deb-packages

--- a/tools/distribute/ubuntu16.04.build-deb.Dockerfile
+++ b/tools/distribute/ubuntu16.04.build-deb.Dockerfile
@@ -7,6 +7,9 @@ RUN     apt-get update \
         && apt-get install -y build-essential libssl-dev libffi-dev \
         ## install py2deb package converter
         && pip3 install --upgrade pip \
+        # Installing setuptools (now in >v34.0.0 dependencies must be installed in advance)
+        && pip3 install wincertstore==0.2 certifi==2016.9.26 six>=1.10.0 packaging>=16.8 appdirs>=1.4.0 \
+        && pip3 install setuptools==34.0.2 \
         && pip3 install py2deb \
         ## generate utf8 locale, otherwise py2deb will result in error!
         && locale-gen en_US.UTF-8 \

--- a/tools/test.Dockerfile
+++ b/tools/test.Dockerfile
@@ -26,6 +26,9 @@ RUN cd /son-cli/ansible \
     && cd /son-cli \
     # Removing bin to avoid badly generated binaries
     && rm -rf bin \
+    # Installing setuptools (now in >v34.0.0 dependencies must be installed in advance)
+    && pip3 install wincertstore==0.2 certifi==2016.9.26 six>=1.10.0 packaging>=16.8 appdirs>=1.4.0 \
+    && pip3 install setuptools==34.0.2 \
     # Bootstrapping the test environment
     && python3.4 bootstrap.py \
     # Generating the test environment


### PR DESCRIPTION
The recent release of setuptools (>34.0.0) requires its dependencies to be previously installed. Please refer to setuptools 34.0.0 release descriptions for more details. This was causing integration tests to
fail.