### PR TITLE
added a configuration file for son profile

### DIFF
--- a/src/son/profile/config.yml
+++ b/src/son/profile/config.yml
@@ -1,0 +1,34 @@
+
+---
+##
+## Some general informaton regarding this 
+## config file.
+##
+descriptor_version: "0.1"
+vendor: "eu.sonata-nfv"
+name: "son profile config file"
+version: "0.2"
+author: "Eduard Maas, Paderborn university, edmaas@mail.uni-paderborn.de" # temporary, feel free to edit to something more appropriate as soon as more people work with this file
+description: "A config file for use in the son profile environment. Currently only holds information about target platforms. Might not work on all systems, as specified files or users might not exist or not meet requirements."
+##
+## Target platforms list.
+##
+## example:
+##   address: "some_adress"
+##   package_port: this port and the next one will be used for the son-emu topology
+##   ssh_port: this port will be used to connect via ssh
+##   ssh_user: this username will be used in the ssh connection. The user needs passless sudo!
+##   ssh_key_loc: path to the ssh key that should be used. This should has to work with the ssh_user specified!
+target_platforms:
+  localhost1:
+    address: "127.0.0.1"
+    package_port: 5000
+    ssh_port: 22
+    ssh_user: "ssh_user"
+    ssh_key_loc: "~/.ssh/id_rsa"
+  localhost2:
+    address: "127.0.0.1"
+    package_port: 6000
+    ssh_port: 22
+    ssh_user: "ssh_user"
+    ssh_key_loc: "~/.ssh/id_rsa"


### PR DESCRIPTION
A configuration file to be used by multiple modules within son-profile. One use is the description of remote hosts for package testing.