### PR TITLE
using python requests iso urllib seems more stable

### DIFF
--- a/src/son/schema/tests/test_integ_Validator.py
+++ b/src/son/schema/tests/test_integ_Validator.py
@@ -28,7 +28,9 @@ import unittest
 import pkg_resources
 import os
 from requests import RequestException
+from requests.exceptions import InvalidURL, HTTPError, MissingSchema
 from son.schema.validator import load_local_schema, load_remote_schema
+
 
 
 class IntLoadSchemaTests(unittest.TestCase):
@@ -63,7 +65,7 @@ class IntLoadSchemaTests(unittest.TestCase):
         Test if it raises a HTTP error with a valid
         but unavailable schema URL.
         """
-        self.assertRaises(RequestException,
+        self.assertRaises(HTTPError,
                           load_remote_schema,
                           "http://somerandomurl.com/artifact.yml")
 
@@ -72,7 +74,7 @@ class IntLoadSchemaTests(unittest.TestCase):
         Test if it raises an error with an invalid
         schema URL.
         """
-        self.assertRaises(ValueError,
+        self.assertRaises(MissingSchema,
                           load_remote_schema,
                           "some.incorrect/..url")
 

--- a/src/son/schema/tests/test_integ_Validator.py
+++ b/src/son/schema/tests/test_integ_Validator.py
@@ -27,7 +27,7 @@
 import unittest
 import pkg_resources
 import os
-from urllib.error import HTTPError
+from requests import RequestException
 from son.schema.validator import load_local_schema, load_remote_schema
 
 
@@ -63,7 +63,7 @@ class IntLoadSchemaTests(unittest.TestCase):
         Test if it raises a HTTP error with a valid
         but unavailable schema URL.
         """
-        self.assertRaises(HTTPError,
+        self.assertRaises(RequestException,
                           load_remote_schema,
                           "http://somerandomurl.com/artifact.yml")
 

--- a/src/son/schema/tests/test_unit_Validator.py
+++ b/src/son/schema/tests/test_unit_Validator.py
@@ -62,15 +62,12 @@ class UnitLoadSchemaTests(unittest.TestCase):
         self.assertEqual(sample_dict, return_dict)
 
     @patch("son.schema.validator.yaml")
-    @patch("son.schema.validator.urllib.request.urlopen.headers."
-           "get_content_charset")
-    @patch("son.schema.validator.urllib.request.urlopen.read.decode")
-    @patch("son.schema.validator.urllib.request.urlopen")
-    def test_load_remote_schema(self, m_urlopen, m_decode, m_cs, m_yaml):
+    @patch("son.schema.validator.requests.get")
+    def test_load_remote_schema(self, m_urlopen, m_yaml):
 
         sample_dict = {"key": "content"}
-        m_decode.return_value = ""
-        m_cs.return_value = ""
+        #m_decode.return_value = ""
+        #m_cs.return_value = ""
         m_yaml.load.return_value = sample_dict
 
         # Ensure that urlopen is accessing the same address of the argument

--- a/src/son/schema/validator.py
+++ b/src/son/schema/validator.py
@@ -34,14 +34,13 @@ import jsonschema
 # using urllib sometimes results in connection reset errors when trying to download remote schema
 # using requests instead
 import requests
-from requests import RequestException
+from requests.exceptions import RequestException
 
 from jsonschema import SchemaError
 from jsonschema import ValidationError
 from son.workspace.workspace import Workspace
 
 log = logging.getLogger(__name__)
-
 
 class SchemaValidator(object):
 
@@ -147,10 +146,10 @@ class SchemaValidator(object):
 
                 return self._schemas_library[template]
 
-            except RequestException:
+            except RequestException as e:
                 log.warning("Could not load schema '{}' from remote "
-                            "location '{}'"
-                            .format(template, schema_addr))
+                            "location '{}', error: {}"
+                            .format(template, schema_addr, e))
         else:
             log.warning("Invalid schema URL '{}'".format(schema_addr))
 
@@ -279,6 +278,7 @@ def load_remote_schema(template_url):
     :return: The loaded schema as a dictionary
     """
     response = requests.get(template_url)
+    response.raise_for_status()
     tf = response.text
     schema = yaml.load(tf)
     assert isinstance(schema, dict)

--- a/src/son/schema/validator.py
+++ b/src/son/schema/validator.py
@@ -32,8 +32,6 @@ import yaml
 import jsonschema
 
 # using urllib sometimes results in connection reset errors when trying to download remote schema
-#import urllib
-#from urllib.request import URLError
 # using requests instead
 import requests
 from requests import RequestException
@@ -280,8 +278,6 @@ def load_remote_schema(template_url):
     :param template_url: The URL of the required schema
     :return: The loaded schema as a dictionary
     """
-    #response = urllib.request.urlopen(template_url)
-    #tf = response.read().decode(response.headers.get_content_charset())
     response = requests.get(template_url)
     tf = response.text
     schema = yaml.load(tf)

--- a/src/son/schema/validator.py
+++ b/src/son/schema/validator.py
@@ -30,8 +30,14 @@ import validators
 import os
 import yaml
 import jsonschema
-import urllib
-from urllib.request import URLError
+
+# using urllib sometimes results in connection reset errors when trying to download remote schema
+#import urllib
+#from urllib.request import URLError
+# using requests instead
+import requests
+from requests import RequestException
+
 from jsonschema import SchemaError
 from jsonschema import ValidationError
 from son.workspace.workspace import Workspace
@@ -143,7 +149,7 @@ class SchemaValidator(object):
 
                 return self._schemas_library[template]
 
-            except URLError:
+            except RequestException:
                 log.warning("Could not load schema '{}' from remote "
                             "location '{}'"
                             .format(template, schema_addr))
@@ -274,8 +280,10 @@ def load_remote_schema(template_url):
     :param template_url: The URL of the required schema
     :return: The loaded schema as a dictionary
     """
-    response = urllib.request.urlopen(template_url)
-    tf = response.read().decode(response.headers.get_content_charset())
+    #response = urllib.request.urlopen(template_url)
+    #tf = response.read().decode(response.headers.get_content_charset())
+    response = requests.get(template_url)
+    tf = response.text
     schema = yaml.load(tf)
     assert isinstance(schema, dict)
     return schema


### PR DESCRIPTION
using urllib sometimes results in connection reset errors when downloading the remote schema. Using python module: requests instead.