### PR TITLE
fixed bug in son-access config parameters

### DIFF
--- a/src/son/access/access.py
+++ b/src/son/access/access.py
@@ -140,7 +140,7 @@ class AccessClient:
         except:
             self.access_token = None
 
-        log.info("Loaded access_token='{}'".format(self.access_token))
+        #log.info("Loaded access_token='{}'".format(self.access_token))
 
         try:
             # retrieve keypair from workspace
@@ -718,12 +718,12 @@ class AccessArgParse(object):
             required=False
         )
         parser.add_argument(
-            "-p", "--platform",
+            "--platform",
             type=str,
             metavar="PLATFORM_ID",
             help="Specify the ID of the Service Platform to use from "
                  "workspace configuration. If not specified will assume the ID"
-                 "in 'default_service_platform'",
+                 " in 'default_service_platform'",
             required=False
         )
         parser.add_argument(
@@ -742,7 +742,7 @@ class AccessArgParse(object):
         for idx in range(1, len(sys.argv)):
             v = sys.argv[idx]
             if (v == "-w" or v == "--workspace" or
-                        v == '-p' or v == "--platform"):
+                    v == "--platform"):
                 command_idx += 2
             elif v == '--debug':
                 command_idx += 1
@@ -772,6 +772,8 @@ class AccessArgParse(object):
 
         self.ac = AccessClient(self.workspace, platform_id=args.platform,
                                log_level=log_level)
+
+
 
         # call sub-command
         getattr(self, args.command)()
@@ -933,6 +935,7 @@ class AccessArgParse(object):
                                   uuid=False)
 
     def config(self):
+
         parser = ArgumentParser(
             prog="son-access [..] config",
             description="Configure access parameters",
@@ -1007,8 +1010,7 @@ class AccessArgParse(object):
                              entries))
             exit(0)
 
-        if not (args.url or args.username or args.password or args.token or
-                    args.default):
+        if not (args.url or args.username or args.password or args.default):
             log.error("At least one of the following arguments must be "
                       "specified: (--url | --username | --password "
                       "| --default)")
@@ -1016,6 +1018,7 @@ class AccessArgParse(object):
 
         # new SP entry in workspace configuration
         if args.new:
+            print("new")
             if self.workspace.get_service_platform(args.platform_id):
                 log.error("Couldn't add entry. Service Platform ID='{}' "
                           "already exists.".format(args.platform_id))

--- a/src/son/workspace/workspace.py
+++ b/src/son/workspace/workspace.py
@@ -293,7 +293,6 @@ class Workspace:
 
     def get_service_platform(self, sp_id):
         if sp_id not in self.service_platforms.keys():
-            print("nah")
             return
         return self.service_platforms[sp_id]
 


### PR DESCRIPTION
The argument `-p` of the optional arguments was in conflict with the argument `-p` of the `config` arguments