### PR TITLE
son-validate: dynamic configuration of validation events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,3 @@ bin/
 /src/son/validate/gui/dist
 src/son/validate/gui/node_modules
 
-

--- a/src/son/validate/api/api.py
+++ b/src/son/validate/api/api.py
@@ -376,7 +376,7 @@ def _validate_object_from_request(object_type):
                             pkg_pubkey=pkg_pubkey)
 
 
-def _config_events():
+def _events_config():
 
     if not request.form:
         return 'No events to configure', 400
@@ -405,6 +405,17 @@ def _config_events():
 
     EventLogger.dump_eventcfg(eventdict)
     return 'OK', 200
+
+
+def _events_list():
+
+    if os.path.isfile('.eventcfg.yml'):
+        eventdict = EventLogger.load_eventcfg('.eventcfg.yml')
+    else:
+        eventdict = EventLogger.load_eventcfg()
+
+    return json.dumps(eventdict, sort_keys=True,
+                      indent=4, separators=(',', ': ')).encode('utf-8')
 
 
 def str2bool(v):
@@ -509,11 +520,13 @@ def validate_service():
 def validate_function():
     return _validate_object_from_request('function')
 
-@app.route('/config/events', methods=['POST'])
-def config_events():
-    return _config_events()
+@app.route('/events/config', methods=['POST'])
+def events_config():
+    return _events_config()
 
-
+@app.route('/events/list', methods=['GET'])
+def events_list():
+    return _events_list()
 
 @app.route('/validations', methods=['GET'])
 def validations():

--- a/src/son/validate/eventcfg.yml
+++ b/src/son/validate/eventcfg.yml
@@ -77,7 +77,7 @@ evt_nsd_top_topgraph_disconnected: warning
 evt_nsd_top_badsection_fwgraph: error
 
 # NSD [topology] - no 'forwarding_graphs' section
-evt_nsd_top_fwgraph_unavailable: none
+evt_nsd_top_fwgraph_unavailable: error
 
 # NSD [topology] - connection point in forwarding graph not defined
 evt_nsd_top_fwgraph_cpoint_undefined: error


### PR DESCRIPTION
This PR enables validation events to be configured dynamically, either using the CLI or the service API.

To customize the events using the CLI, create a file `eventcfg.yml` in the current working directory and add the events, and the corresponding values, you want to change.

Using the service API:
- to configure use: `/events/config` endpoint and put the events and corresponding values in the body of the request
- to list the current config: `/events/list`