### PR TITLE
Fix: son-validate crashes with NoneType has no attribute .id when a N…

### DIFF
--- a/src/son/validate/validate.py
+++ b/src/son/validate/validate.py
@@ -956,7 +956,7 @@ class Validator(object):
                                                cp),
                                        source_id,
                                        'evt_nsd_top_fwpath_disrupted',
-                                       event_id=func.id)
+                                       event_id=source_id)
 
                         pair_complete = True
 


### PR DESCRIPTION
…SD with a loop in its VNFFP is validated.

Signed-off-by: Manuel Peuster <manuel@peuster.de>